### PR TITLE
Fix encapsulation: make Order.TotalAmount and Discount private set

### DIFF
--- a/content/src/CA.And.DDD.Template.Domain/Orders/Order.cs
+++ b/content/src/CA.And.DDD.Template.Domain/Orders/Order.cs
@@ -16,8 +16,8 @@ namespace CA.And.DDD.Template.Domain.Orders
         private readonly List<OrderItem> _orderItems;
         public IReadOnlyCollection<OrderItem> OrderItems => _orderItems.AsReadOnly();
 
-        public Money TotalAmount { get; internal set; } = new Money(0);
-        public Discount Discount { get; internal set; }
+        public Money TotalAmount { get; private set; } = new Money(0);
+        public Discount Discount { get; private set; }
         private Order()
         {
 
@@ -78,6 +78,17 @@ namespace CA.And.DDD.Template.Domain.Orders
                 TotalAmount = new Money(orderAmount);
                 return TotalAmount;
             }
+        }
+
+        /// <summary>
+        /// Applies a loyalty discount based on the customer's spending over the last 31 days.
+        /// Intended to be called by <see cref="OrderDomainService"/> once it has determined
+        /// the applicable discount amount.
+        /// </summary>
+        public void ApplyLoyaltyDiscount(decimal discountAmount)
+        {
+            Discount = new Discount(discountAmount, DiscountType.TotalSpentMoneyInLast31Days);
+            TotalAmount = new Money(TotalAmount.Amount - discountAmount);
         }
     }
 }

--- a/content/src/CA.And.DDD.Template.Domain/Orders/OrderDomainService.cs
+++ b/content/src/CA.And.DDD.Template.Domain/Orders/OrderDomainService.cs
@@ -24,8 +24,7 @@ namespace CA.And.DDD.Template.Domain.Orders
                     if (discount > 0)
                     {
                         var discountAmount = order.TotalAmount.Amount * discount;
-                        order.Discount = new Discount(discountAmount, DiscountType.TotalSpentMoneyInLast31Days);
-                        order.TotalAmount = new Money(order.TotalAmount.Amount - discountAmount);
+                        order.ApplyLoyaltyDiscount(discountAmount);
                     }
 
                 }


### PR DESCRIPTION
Order.TotalAmount and Order.Discount were internal set, letting any class in the Domain assembly mutate them directly, bypassing CalculateTotalAmount()'s invariants. OrderDomainService relied on this to apply a loyalty discount from outside the aggregate.

Both properties are now private set. Added Order.ApplyLoyaltyDiscount() so OrderDomainService expresses the same behavior through the aggregate's public API instead of reaching into its state.